### PR TITLE
Fix CCITT CRC

### DIFF
--- a/crc16.go
+++ b/crc16.go
@@ -10,8 +10,9 @@ const (
 	IBM = 0xA001
 
 	// CCITT is used by X.25, V.41, HDLC FCS, XMODEM, Bluetooth, PACTOR, SD, ...
-	// CCITT forward is 0x8408. Reverse is 0x1021. And we do CCITT in reverse.
-	CCITT = 0x1021
+	// CCITT forward is 0x8408. Reverse is 0x1021.
+	CCITT      = 0x8408
+	CCITTFalse = 0x1021
 
 	// SCSI is used by SCSI
 	SCSI = 0xEDD1
@@ -24,7 +25,10 @@ type Table [256]uint16
 var IBMTable = makeTable(IBM)
 
 // CCITTTable is the table for the CCITT polynomial.
-var CCITTTable = makeBitsReversedTable(CCITT)
+var CCITTTable = makeTable(CCITT)
+
+// CCITTFalseTable is the table for CCITT-FALSE.
+var CCITTFalseTable = makeBitsReversedTable(CCITTFalse)
 
 // SCSITable is the table for the SCSI polynomial.
 var SCSITable = makeTable(SCSI)
@@ -96,9 +100,14 @@ func Checksum(data []byte, tab *Table) uint16 { return Update(0, tab, data) }
 // using the IBM polynomial.
 func ChecksumIBM(data []byte) uint16 { return update(0, IBMTable, data) }
 
+// ChecksumCCITTFalse returns the CRC-16 checksum using
+// what some call the CCITT-False polynomial, which matches what is used
+// by Perl Digest/CRC and Boost for example.
+func ChecksumCCITTFalse(data []byte) uint16 { return updateBitsReversed(0xffff, CCITTFalseTable, data) }
+
 // ChecksumCCITT returns the CRC-16 checksum of data
 // using the CCITT polynomial.
-func ChecksumCCITT(data []byte) uint16 { return updateBitsReversed(0xffff, CCITTTable, data) }
+func ChecksumCCITT(data []byte) uint16 { return update(0, CCITTTable, data) }
 
 // ChecksumSCSI returns the CRC-16 checksum of data
 // using the SCSI polynomial.

--- a/crc16.go
+++ b/crc16.go
@@ -6,13 +6,14 @@ package crc16
 
 // Predefined polynomials.
 const (
-	// Used by Bisync, Modbus, USB, ANSI X3.28, SIA DC-07, ...
+	// IBM is used by Bisync, Modbus, USB, ANSI X3.28, SIA DC-07, ...
 	IBM = 0xA001
 
-	// Used by X.25, V.41, HDLC FCS, XMODEM, Bluetooth, PACTOR, SD, ...
-	CCITT = 0x8408
+	// CCITT is used by X.25, V.41, HDLC FCS, XMODEM, Bluetooth, PACTOR, SD, ...
+	// CCITT forward is 0x8408. Reverse is 0x1021. And we do CCITT in reverse.
+	CCITT = 0x1021
 
-	// Used by SCSI
+	// SCSI is used by SCSI
 	SCSI = 0xEDD1
 )
 

--- a/crc16_test.go
+++ b/crc16_test.go
@@ -36,11 +36,11 @@ func BenchmarkMakeTable(b *testing.B) {
 	}
 }
 
-func TestCCITT(t *testing.T) {
+func TestCCITTFalse(t *testing.T) {
 	data := []byte("testdata")
 	target := uint16(0xDC7C)
 
-	actual := ChecksumCCITT(data)
+	actual := ChecksumCCITTFalse(data)
 	if actual != target {
 		t.Fatalf("CCITT checksum did not return the correct value, expected %x, received %x", target, actual)
 	}

--- a/crc16_test.go
+++ b/crc16_test.go
@@ -35,3 +35,13 @@ func BenchmarkMakeTable(b *testing.B) {
 		MakeTable(0xA001)
 	}
 }
+
+func TestCCITT(t *testing.T) {
+	data := []byte("testdata")
+	target := uint16(0xDC7C)
+
+	actual := ChecksumCCITT(data)
+	if actual != target {
+		t.Fatalf("CCITT checksum did not return the correct value, expected %x, received %x", target, actual)
+	}
+}


### PR DESCRIPTION
I was looking for a quick Go library for the CCITT CRC. This was the first Google result. Imagine how I felt when it didn't match other implementations! Specifically, Perl's Digest/CRC and the various sorts of C code around the net like this one http://www.menie.org/georges/embedded/crc16.html

Further research shows that perhaps what I implemented is CCITT-FALSE. Still, it is the one that matches the other things I needed to match.
See:
http://reveng.sourceforge.net/crc-catalogue/16.htm#crc.cat.crc-16-ccitt-false

I hope that I did the changes correctly and that this helps you or someone.

Thanks!
