### PR TITLE
Add CRC-16 checksums without XOR in or out

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,23 @@
-[![GoDoc](https://godoc.org/github.com/howeyc/crc16?status.svg)](https://godoc.org/github.com/howeyc/crc16)
+[![GoDoc](https://godoc.org/github.com/howeyc/crc16?status.svg)](https://godoc.org/github.com/howeyc/crc16) [![Build Status](https://secure.travis-ci.org/howeyc/crc16.png?branch=master)](http://travis-ci.org/howeyc/crc16)
 
-[![Build Status](https://secure.travis-ci.org/howeyc/crc16.png?branch=master)](http://travis-ci.org/howeyc/crc16)
+# CRC16
+A Go package implementing the 16-bit Cyclic Redundancy Check, or CRC-16, checksum.
+
+## Usage
+To generate the hash of a byte slice, use the [`crc16.Checksum()`](https://godoc.org/github.com/howeyc/crc16#Checksum) function:
+```golang
+import "github.com/howeyc/crc16"
+
+data := byte("test")
+checksum := crc16.Checksum(data, crc16.IBMTable)
+```
+
+The package provides [the following](https://godoc.org/github.com/howeyc/crc16#pkg-variables) hashing tables. For each of these tables, a shorthand can be used.
+```golang
+// This is the same as crc16.Checksum(data, crc16.IBMTable)
+checksum := crc16.ChecksumIBM(data)
+```
 
 ## Changelog
-
 * 27.03.2017 - Added MBus checksum
+* 27.05.2017 - Added checksum function without XOR

--- a/crc16.go
+++ b/crc16.go
@@ -107,6 +107,19 @@ func update(crc uint16, tab *Table, p []byte) uint16 {
 	return ^crc
 }
 
+func updateNoXOR(crc uint16, tab *Table, p []byte) uint16 {
+	for _, v := range p {
+		crc = tab.entries[byte(crc)^v] ^ (crc >> 8)
+	}
+
+	return crc
+}
+
+// UpdateNoXOR is the same Update, but without XOR in and XOR out
+func UpdateNoXOR(crc uint16, tab *Table, p []byte) uint16 {
+	return updateNoXOR(crc, tab, p)
+}
+
 // Update returns the result of adding the bytes in p to the crc.
 func Update(crc uint16, tab *Table, p []byte) uint16 {
 	if tab.reversed {
@@ -119,6 +132,9 @@ func Update(crc uint16, tab *Table, p []byte) uint16 {
 // Checksum returns the CRC-16 checksum of data
 // using the polynomial represented by the Table.
 func Checksum(data []byte, tab *Table) uint16 { return Update(0, tab, data) }
+
+// ChecksumNoXOR is the same as Checksum, but with no XOR in and no XOR out
+func ChecksumNoXOR(data []byte, tab *Table) uint16 { return UpdateNoXOR(0, tab, data) }
 
 // ChecksumIBM returns the CRC-16 checksum of data
 // using the IBM polynomial.

--- a/doc.go
+++ b/doc.go
@@ -1,8 +1,0 @@
-// Copyright 2013 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
-// Package crc16 implements the 16-bit cyclic redundancy check, or CRC-16,
-// checksum. See http://en.wikipedia.org/wiki/Cyclic_redundancy_check for
-// information.
-package crc16


### PR DESCRIPTION
I recently decided to read out my 'smart' meter for electricity, gas, and water, which complies to the [DSMR v4.2.2](http://www.netbeheernederland.nl/publicaties/publicatie/?documentregistrationid=797212672) specification.

However, the so-called 'telegram' uses a CRC-16 checksum without XOR in or XOR out (See § 5.2 in the document mentioned above). This functionality was not present in this package or any other CRC-16 packages I could find, so I decided to add it here.

I also changed the README a little, and I removed the empty `doc.go` file.